### PR TITLE
Fix: Replace unstable is_multiple_of for Rust < 1.87 compatibility

### DIFF
--- a/src/equivalence/wilcoxon_tost.rs
+++ b/src/equivalence/wilcoxon_tost.rs
@@ -405,7 +405,7 @@ fn median_sorted(sorted: &[f64]) -> f64 {
     if n == 0 {
         return f64::NAN;
     }
-    if n.is_multiple_of(2) {
+    if n % 2 == 0 {
         (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
     } else {
         sorted[n / 2]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Allow manual modulo checks for Rust < 1.87 compatibility (is_multiple_of was stabilized in 1.87)
+#![allow(clippy::manual_is_multiple_of)]
+
 pub mod categorical;
 pub mod correlation;
 pub mod distributional;

--- a/src/modern/mmd.rs
+++ b/src/modern/mmd.rs
@@ -303,7 +303,7 @@ fn median_heuristic_1d(data: &[f64]) -> f64 {
     // Find median
     distances.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let mid = distances.len() / 2;
-    if distances.len().is_multiple_of(2) {
+    if distances.len() % 2 == 0 {
         (distances[mid - 1] + distances[mid]) / 2.0
     } else {
         distances[mid]

--- a/src/nonparametric/wilcoxon.rs
+++ b/src/nonparametric/wilcoxon.rs
@@ -488,7 +488,7 @@ fn mann_whitney_estimate_ci(
     diffs.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
     // Hodges-Lehmann estimate: median of pairwise differences
-    let estimate = if n_pairs.is_multiple_of(2) {
+    let estimate = if n_pairs % 2 == 0 {
         (diffs[n_pairs / 2 - 1] + diffs[n_pairs / 2]) / 2.0
     } else {
         diffs[n_pairs / 2]
@@ -592,7 +592,7 @@ fn wilcoxon_estimate_ci(
     walsh.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
     // Hodges-Lehmann estimate: median of Walsh averages
-    let estimate = if n_walsh.is_multiple_of(2) {
+    let estimate = if n_walsh % 2 == 0 {
         (walsh[n_walsh / 2 - 1] + walsh[n_walsh / 2]) / 2.0
     } else {
         walsh[n_walsh / 2]


### PR DESCRIPTION
## Summary
- Replace all 4 occurrences of `is_multiple_of(2)` with `% 2 == 0` for compatibility with Rust < 1.87
- Add clippy allow directive to suppress `manual_is_multiple_of` lint

Fixes #4

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` - all 180 library tests pass
- [x] `cargo test --doc` - all 31 doc tests pass
- [x] `cargo clippy` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)